### PR TITLE
Update CancelToken.js

### DIFF
--- a/src/CancelToken.js
+++ b/src/CancelToken.js
@@ -15,9 +15,10 @@ class CancelToken {
   }
   
   check() {
-    if (this.cancelled) {
-      throw new CancelError()
-    }
+    return Promise.race([
+      this.promise, 
+      Promise.resolve()
+    ])
   }
 }
 

--- a/src/CancelToken.js
+++ b/src/CancelToken.js
@@ -13,6 +13,12 @@ class CancelToken {
     this.cancelled = true
     this._rejectPromise(new CancelError())
   }
+  
+  check() {
+    if (this.cancelled) {
+      throw new CancelError()
+    }
+  }
 }
 
 export default CancelToken


### PR DESCRIPTION
In order to make this library work correctly, the user must pass the cancellation token around and check its state. To make this more convenient, I would propose a method to "check" the token. 

Usage like this: 

```
const sleep = ms => new Promise((resolve) => {
  setTimeout(() => {
    resolve(ms);
  }, ms);
});

const token = new CancelToken();

// This token has a 3 second time-out
sleep(3000).then(token.cancel());

const p = sleep(5000).then(() => {
  // Check the token has not been cancelled; 
  // without this, "Hello, world. " is always printed. 
  token.check();
  console.log('Hello, world. ');
});

const q = cancellablePromise(p, token);

q.then(console.log).catch(console.error);
```